### PR TITLE
Remove outfile only if it is distinct from input file.

### DIFF
--- a/pyAesCrypt/crypto.py
+++ b/pyAesCrypt/crypto.py
@@ -250,7 +250,8 @@ def decryptFile(infile, outfile, passw, bufferSize):
                                       inputFileSize)
                     except ValueError as exd:
                         # remove output file on error
-                        remove(outfile)
+                        if infile != outfile:
+                            remove(outfile)
                         # re-raise exception
                         raise ValueError(str(exd))
             


### PR DESCRIPTION
At present, the script removes the `outfile` if an exception occurs while de-crypting the stream. However, if the `infile` and  `outfile` are the same, this can lead to the `infile` being removed.

Since there's no warning or checks in the code against the `infile` and `outfile` arguments being the same, I'm assuming this is a valid use case.