### PR TITLE
Deprecate decryptStream inputLength parameter

### DIFF
--- a/pyAesCrypt/test_crypto.py
+++ b/pyAesCrypt/test_crypto.py
@@ -328,7 +328,8 @@ class TestExceptions(unittest.TestCase):
         
         # try to decrypt file
         # ...and check that ValueError is raised
-        self.assertRaisesRegex(ValueError, "File is corrupted.",
+        self.assertRaisesRegex(ValueError, ("Bad HMAC "
+                                                "\(file is corrupted\)."),
                                pyAesCrypt.decryptFile, self.tfile + '.aes',
                                self.tfile + '.decr', password, bufferSize)
                                

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
     README = readme.read()
 
 setup(name='pyAesCrypt',
-    version='6.0.0',
+    version='6.1.0',
     packages = find_packages(),
     include_package_data=True,
     description='Encrypt and decrypt files and streams in AES Crypt format (version 2)',


### PR DESCRIPTION
Hi 👋 

This PR removes the need to call `os.stat`, `decryptStream` can now be called with a (remote) stream for which the total size is unknown.

- Avoid i/o overhead of having to read the whole remote to disk once and then read from there into `decryptStream`
- Simplify the code, now having only 1 occurrence of `fOut.write`
- Run [`black`](https://github.com/python/black) code formatting on `crypto.py`
- Ensure tests still pass
- Emit DeprecationWarning when inputLength parameter is passed
- Bump minor version (non-breaking change)