### PR TITLE
Fix Issue #44: Input stream valid for pyAesCrypt.decryptStream v6.0.0…

### DIFF
--- a/pyAesCrypt/test_crypto.py
+++ b/pyAesCrypt/test_crypto.py
@@ -225,6 +225,25 @@ class TestBS(unittest.TestCase):
         # check that the original file and the output file are equal
         self.assertTrue(filecmp.cmp(filenames[4], decfilenames[4]))
 
+    # quick test for binary stream functions with simplest possible input stream
+    def test_bs_simplefile(self):
+        # encrypt
+        with open(filenames[4], "rb") as fIn:
+            with open(encfilenames[4], "wb") as fOut:
+                pyAesCrypt.encryptStream(SimpleFile(fIn), fOut, password, bufferSize)
+
+        # get encrypted file size
+        encFileSize = os.stat(encfilenames[4]).st_size
+
+        # decrypt
+        with open(encfilenames[4], "rb") as fIn:
+            with open(decfilenames[4], "wb") as fOut:
+                # decrypt file stream
+                pyAesCrypt.decryptStream(SimpleFile(fIn), fOut, password, bufferSize)
+
+        # check that the original file and the output file are equal
+        self.assertTrue(filecmp.cmp(filenames[4], decfilenames[4]))
+
 
 
 # test exceptions
@@ -375,5 +394,16 @@ class TestExceptions(unittest.TestCase):
         # check that the original file was not modified
         self.assertTrue(filecmp.cmp(self.tfile, self.tfilebak))
     
+# simple file access class with only read() and tell() methods, nothing more
+class SimpleFile:
+    def __init__(self, f):
+        self.f = f
+
+    def read(self, size = -1):
+        return self.f.read(size)
+
+    def tell(self):
+        return self.f.tell()
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
… causes exception

My changes allow my simple test program included in Issue #44 to pass, but I don't know how to test the package exhaustively. 

Please feel free to let me know how to do so and also to ask any questions you may have about my changes.